### PR TITLE
Add existing planning name check

### DIFF
--- a/src/main/java/com/asialocalguide/gateway/core/repository/PlanningRepository.java
+++ b/src/main/java/com/asialocalguide/gateway/core/repository/PlanningRepository.java
@@ -1,8 +1,9 @@
 package com.asialocalguide.gateway.core.repository;
 
 import com.asialocalguide.gateway.core.domain.planning.Planning;
+import com.asialocalguide.gateway.core.repository.custom.CustomPlanningRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PlanningRepository extends JpaRepository<Planning, Long> {}
+public interface PlanningRepository extends JpaRepository<Planning, Long>, CustomPlanningRepository {}

--- a/src/main/java/com/asialocalguide/gateway/core/repository/custom/CustomPlanningRepository.java
+++ b/src/main/java/com/asialocalguide/gateway/core/repository/custom/CustomPlanningRepository.java
@@ -1,0 +1,8 @@
+package com.asialocalguide.gateway.core.repository.custom;
+
+import java.util.UUID;
+
+public interface CustomPlanningRepository {
+
+  boolean existsByAppUserIdAndName(UUID appUserId, String name);
+}

--- a/src/main/java/com/asialocalguide/gateway/core/repository/custom/CustomPlanningRepositoryImpl.java
+++ b/src/main/java/com/asialocalguide/gateway/core/repository/custom/CustomPlanningRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.asialocalguide.gateway.core.repository.custom;
+
+import com.asialocalguide.gateway.core.domain.planning.QPlanning;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.UUID;
+
+public class CustomPlanningRepositoryImpl implements CustomPlanningRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public CustomPlanningRepositoryImpl(JPAQueryFactory queryFactory) {
+    this.queryFactory = queryFactory;
+  }
+
+  @Override
+  public boolean existsByAppUserIdAndName(UUID appUserId, String name) {
+    QPlanning planning = QPlanning.planning;
+
+    return queryFactory
+            .selectOne()
+            .from(planning)
+            .where(planning.appUser.id.eq(appUserId).and(planning.name.eq(name)))
+            .fetchFirst()
+        != null;
+  }
+}

--- a/src/main/resources/db/migration/V1_0_2__unique_planning_name.sql
+++ b/src/main/resources/db/migration/V1_0_2__unique_planning_name.sql
@@ -1,0 +1,3 @@
+
+
+CREATE UNIQUE INDEX uq_app_user_id_name ON planning USING btree (app_user_id, name);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to prevent users from creating plannings with duplicate names.
- **Bug Fixes**
  - Improved error handling for duplicate planning names, providing clear feedback when a name is already in use.
- **Tests**
  - Added a test to verify that an error is thrown when attempting to save a planning with a duplicate name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->